### PR TITLE
Update User model and add tests

### DIFF
--- a/apps/api/config/test.exs
+++ b/apps/api/config/test.exs
@@ -15,7 +15,3 @@ config :guardian, Guardian,
 
 # Print only warnings and errors during test
 config :logger, level: :warn
-
-# Reduce complexity of encryption in tests, speeding them up
-config :comeonin, :bcrypt_log_rounds, 4
-config :comeonin, :pbkdf2_rounds, 1

--- a/apps/api/lib/api/user/authorization.ex
+++ b/apps/api/lib/api/user/authorization.ex
@@ -20,10 +20,6 @@ defmodule API.User.Authorization do
     Comeonin.Bcrypt.dummy_checkpw
     false
   end
-  defp check_password(password, user), do: Comeonin.Bcrypt.checkpw(password, user.password)
 
-  def hash_password(%{"password" => password} = params) do
-    hashed_password = Comeonin.Bcrypt.hashpwsalt(password)
-    Map.put(params, "password", hashed_password)
-  end
+  defp check_password(password, user), do: Comeonin.Bcrypt.checkpw(password, user.encrypted_password)
 end

--- a/apps/api/lib/api/user/user.ex
+++ b/apps/api/lib/api/user/user.ex
@@ -5,10 +5,8 @@ defmodule API.User do
 
   alias API.User.{Authorization}
 
-  def create_user(attrs) do
-    attrs
-    |> Authorization.hash_password
-    |> DB.User.create
+  def create(attrs) do
+    DB.User.create(attrs)
   end
 
   def login(attrs), do: Authorization.authorize(attrs)

--- a/apps/api/lib/api/web/controllers/user_controller.ex
+++ b/apps/api/lib/api/web/controllers/user_controller.ex
@@ -2,7 +2,7 @@ defmodule API.Web.UserController do
   use API.Web, :controller
 
   def create(conn, params) do
-    case API.User.create_user(params) do
+    case API.User.create(params) do
       {:ok, user} ->
         conn
         |> put_status(:created)

--- a/apps/api/mix.exs
+++ b/apps/api/mix.exs
@@ -20,7 +20,7 @@ defmodule API.Mixfile do
   # Type `mix help compile.app` for more information.
   def application do
     [mod: {API.Application, []},
-     extra_applications: [:comeonin, :db, :logger, :guardian, :runtime_tools]]
+     extra_applications: [:db, :logger, :guardian, :runtime_tools]]
   end
 
   # Specifies which paths to compile per environment.
@@ -35,7 +35,6 @@ defmodule API.Mixfile do
      {:phoenix_pubsub, "~> 1.0"},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
-     {:comeonin, "~> 3.2"},
      {:db, in_umbrella: true},
      {:guardian, "~> 0.14"},
      {:credo, "~> 0.8.4"}]

--- a/apps/api/test/api/web/controllers/user_controller_test.exs
+++ b/apps/api/test/api/web/controllers/user_controller_test.exs
@@ -1,16 +1,23 @@
 defmodule API.Web.UserControllerTest do
-  use API.Web.ConnCase, async: false
+  use API.Web.ConnCase
 
+  @username "dude"
   @email "email@email.com"
   @password "password"
 
+  @user_params %{
+    "username" => @username,
+    "email" => @email,
+    "password" => @password
+  }
+
   test "POST /user", %{conn: conn} do
-    res = post(conn, "/user", %{email: @email, password: @password})
+    res = post(conn, "/user", @user_params)
     assert res.status == 201
   end
 
   test "POST /user/login with correct credentials", %{conn: conn} do
-    API.User.create_user(%{"email" => @email, "password" => @password})
+    API.User.create(@user_params)
     res = post(conn, "/user/login", %{email: @email, password: @password})
     assert res.status == 201
 
@@ -22,13 +29,13 @@ defmodule API.Web.UserControllerTest do
   end
 
   test "POST /user/login with incorrect credentials", %{conn: conn} do
-    API.User.create_user(%{"email" => @email, "password" => @password})
+    API.User.create(@user_params)
     res = post(conn, "/user/login", %{email: @email, password: "hacking"})
     assert res.status == 401
   end
 
   test "POST /user/refresh with a valid token", %{conn: conn} do
-    {:ok, user} = API.User.create_user(%{"email" => @email, "password" => @password})
+    {:ok, user} = API.User.create(@user_params)
     {:ok, token, _} = Guardian.encode_and_sign(user, :access)
 
     res =
@@ -46,7 +53,7 @@ defmodule API.Web.UserControllerTest do
   end
 
   test "POST /user/refresh with a invalid token", %{conn: conn} do
-    {:ok, _user} = API.User.create_user(%{"email" => @email, "password" => @password})
+    {:ok, _user} = API.User.create(@user_params)
 
     res =
       conn

--- a/apps/db/config/test.exs
+++ b/apps/db/config/test.exs
@@ -7,3 +7,7 @@ config :db, DB.Repo,
   password: "postgres",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+# Reduce complexity of encryption in tests, speeding them up
+config :comeonin, :bcrypt_log_rounds, 4
+config :comeonin, :pbkdf2_rounds, 1

--- a/apps/db/mix.exs
+++ b/apps/db/mix.exs
@@ -19,14 +19,15 @@ defmodule Db.Mixfile do
   defp elixirc_paths(_), do: ["lib"]
 
   def application do
-    [extra_applications: [:logger, :postgrex, :ecto],
+    [extra_applications: [:logger, :postgrex, :ecto, :comeonin],
      mod: {DB.Application, []}]
   end
 
   defp deps do
     [
       {:ecto, "~> 2.1"},
-      {:postgrex, "~> 0.13.3"}
+      {:postgrex, "~> 0.13.3"},
+      {:comeonin, "~> 3.2"},
     ]
   end
 end

--- a/apps/db/priv/repo/migrations/20170720012856_create_user.exs
+++ b/apps/db/priv/repo/migrations/20170720012856_create_user.exs
@@ -3,10 +3,14 @@ defmodule DB.Repo.Migrations.CreateUser do
 
   def change do
     create table(:users) do
-      add :email,    :string
-      add :password, :string
+      add :username, :string, null: false
+      add :email,    :string, null: false
+      add :encrypted_password, :string, null: false
 
       timestamps()
     end
+
+    create unique_index(:users, :username)
+    create unique_index(:users, :email)
   end
 end

--- a/apps/db/test/user_test.exs
+++ b/apps/db/test/user_test.exs
@@ -1,0 +1,54 @@
+defmodule UserTest do
+  use DB.ModelCase
+
+  @params %{
+    username: "Obi-Wan",
+    email: "obi-wan@jedicouncil.org",
+    password: "ihavethehighground"
+  }
+
+  def is_valid(changeset) do
+    %Ecto.Changeset{valid?: valid} = changeset
+
+    valid
+  end
+
+  describe "changesets" do
+    test "changeset is valid with username, email, password" do
+      changeset = DB.User.registration_changeset(%DB.User{}, @params)
+
+      assert is_valid(changeset)
+    end
+
+    test "changeset is invalid with improper email format" do
+      params = %{@params | email: "wrong"}
+      changeset = DB.User.registration_changeset(%DB.User{}, params)
+
+      assert not is_valid(changeset)
+    end
+
+    test "changeset is invalid with improper password length" do
+      params = %{@params | password: "short"}
+      changeset = DB.User.registration_changeset(%DB.User{}, params)
+
+      assert not is_valid(changeset)
+    end
+  end
+
+  describe "model" do
+    test "cannot create a user with existing username" do
+      DB.User.registration_changeset(%DB.User{}, @params) |> DB.Repo.insert!
+      {:error, _changeset} =
+        DB.User.registration_changeset(%DB.User{}, @params)
+        |> DB.Repo.insert
+    end
+
+    test "cannot create a user with existing email" do
+      DB.User.registration_changeset(%DB.User{}, @params) |> DB.Repo.insert!
+      params = %{@params | username: "dude"}
+      {:error, _changeset} =
+        DB.User.registration_changeset(%DB.User{}, params)
+        |> DB.Repo.insert
+    end
+  end
+end


### PR DESCRIPTION
Notes:

- `users` table (migration)
  - add `username`, a non-nullable field
  - change `password` to `encrypted_password` for clarity
  - make `username`, `email`, and `encrypted_password` non-nullable
  - make `username` and `email` unique indexes
- `User` schema/changesets
  - add virtual `password` field
  - add `registration_changeset`, which will encrypt the password and save it as well as make validations for uniqueness, password length, and email regex (basic)
- API
  - change `create_user` to `create`

