### PR TITLE
Convert foreign key errors to changesets on Player create

### DIFF
--- a/apps/db/lib/player/player.ex
+++ b/apps/db/lib/player/player.ex
@@ -29,5 +29,7 @@ defmodule DB.Player do
     struct
     |> cast(params, @fields)
     |> validate_required(@fields)
+    |> assoc_constraint(:user)
+    |> assoc_constraint(:game)
   end
 end

--- a/apps/db/test/player_test.exs
+++ b/apps/db/test/player_test.exs
@@ -28,5 +28,19 @@ defmodule DB.PlayerTest do
       assert player.game.id == game.id
       assert player.user.id == user.id
     end
+
+    test "with invalid game id" do
+      {:ok, user} = User.create(@user_params)
+
+      {:error, changeset} = Player.create(user.id, 3)
+
+      assert %{errors: [game: _]} = changeset
+    end
+
+    test "with invalid user id" do
+      {:error, changeset} = Player.create(2, 3)
+
+      assert %{errors: [user: _]} = changeset
+    end
   end
 end


### PR DESCRIPTION
Using `assoc_constraint` will convert DB foreign key errors to changesets so that we can return them back to the client