### PR TITLE
Ensure authentication on non-User resources

### DIFF
--- a/apps/api/lib/api/web/controllers/game_controller.ex
+++ b/apps/api/lib/api/web/controllers/game_controller.ex
@@ -2,8 +2,6 @@ defmodule API.Web.GameController do
   use API.Web, :controller
   alias Ecto.Multi
 
-  plug Guardian.Plug.EnsureAuthenticated, handler: __MODULE__
-
   def index(conn, _params) do
     games =
       conn
@@ -35,11 +33,5 @@ defmodule API.Web.GameController do
         |> put_status(422)
         |> render(API.Web.ErrorView, "422.json", changeset)
     end
-  end
-
-  def unauthenticated(conn, _params) do
-    conn
-    |> put_status(401)
-    |> render(API.Web.ErrorView, "401.json")
   end
 end

--- a/apps/api/lib/api/web/controllers/user_controller.ex
+++ b/apps/api/lib/api/web/controllers/user_controller.ex
@@ -46,6 +46,12 @@ defmodule API.Web.UserController do
     end
   end
 
+  def unauthenticated(conn, _params) do
+    conn
+    |> put_status(401)
+    |> render(API.Web.ErrorView, "401.json")
+  end
+
   defp authorization_headers(conn, token, exp) do
     conn
     |> put_resp_header("authorization", token)

--- a/apps/api/lib/api/web/router.ex
+++ b/apps/api/lib/api/web/router.ex
@@ -7,6 +7,11 @@ defmodule API.Web.Router do
     plug Guardian.Plug.LoadResource
   end
 
+  pipeline :auth do
+    plug Guardian.Plug.EnsureAuthenticated,
+      handler: API.Web.UserController
+  end
+
   scope "/", API.Web do
     pipe_through :api
 
@@ -21,6 +26,9 @@ defmodule API.Web.Router do
       post "/login", UserController, :login
       post "/refresh", UserController, :refresh
     end
+
+    # All routes after this pipeline will require authentication
+    pipe_through :auth
 
     resources "/games", GameController, only: [:index, :create]
   end


### PR DESCRIPTION
There are a number of ways to do this, but opted to add an `auth` pipeline that requires auth, that builds on the existing `api` pipeline. From the docs:
> Every time `pipe_through/1` is called, the new pipelines are appended to the ones previously given.

