### PR TITLE
Update User search query to take single param

### DIFF
--- a/api_docs/user.md
+++ b/api_docs/user.md
@@ -4,18 +4,14 @@
 
 `GET /v1/users/`
 
-This endpoint performs a fuzzy search for Users. It does this by calculating the Levenshtein distance, returning up to 10 entries with a distance of no greater than 5. It takes query params, either `username` or `email`.
+This endpoint performs a fuzzy search for Users. It does this by calculating the Levenshtein distance, returning up to 10 entries with a distance of no greater than the configured limit (defaults to 5). It takes query params, either `username` or `email`.
 
 **Headers:**
 
 `Authorization: your-token`
 
-**Query Parameters:**
-
-`username` or `email`
-
 **Example Request:**
-`GET /v1/users/?username=thedude`
+`GET /v1/users/?q=thedude`
 
 **Example Response:**
 ```json

--- a/apps/api/lib/api/web/controllers/user_controller.ex
+++ b/apps/api/lib/api/web/controllers/user_controller.ex
@@ -3,23 +3,16 @@ defmodule API.Web.UserController do
 
   action_fallback API.Web.FallbackController
 
-  def search(conn, %{"email" => email}) do
-    users = API.User.search_users(email: email)
+  def search(conn, %{"q" => query}) do
+    users = API.User.search_users(query)
 
-    conn
-    |> put_status(:ok)
-    |> render(%{users: users})
-  end
-
-  def search(conn, %{"username" => username}) do
-    users = API.User.search_users(username: username)
     conn
     |> put_status(:ok)
     |> render(%{users: users})
   end
 
   def search(conn, _params) do
-    msg = "Missing search parameter. Choose `email` or `username`."
+    msg = "Missing or invalid search query parameter."
     conn
     |> put_status(:bad_request)
     |> json(%{errors: [msg]})

--- a/apps/api/test/api/web/controllers/user_controller_test.exs
+++ b/apps/api/test/api/web/controllers/user_controller_test.exs
@@ -24,7 +24,7 @@ defmodule API.Web.UserControllerTest do
       res =
         conn
         |> put_req_header("authorization", token)
-        |> get(@base_url, %{username: @username})
+        |> get(@base_url, %{q: @username})
 
       assert res.status == 200
       body = json_response(res)
@@ -36,7 +36,7 @@ defmodule API.Web.UserControllerTest do
       res =
         conn
         |> put_req_header("authorization", token)
-        |> get(@base_url, %{email: @email})
+        |> get(@base_url, %{q: @email})
 
       assert res.status == 200
       body = json_response(res)
@@ -49,6 +49,15 @@ defmodule API.Web.UserControllerTest do
         conn
         |> put_req_header("authorization", token)
         |> get(@base_url, %{zombie: "brains"})
+
+      assert res.status == 400
+    end
+
+    test "with no parameter returns an error", %{conn: conn, token: token} do
+      res =
+        conn
+        |> put_req_header("authorization", token)
+        |> get(@base_url, %{})
 
       assert res.status == 400
     end

--- a/apps/db/lib/user/user.ex
+++ b/apps/db/lib/user/user.ex
@@ -40,31 +40,19 @@ defmodule DB.User do
   end
 
   @doc """
-  Searches for users by `username`. Uses levenshtein distance
-  to determine matches, up to a distance of 5.
+  Searches for users by `email` or `username`. Uses levenshtein distance
+  to determine matches, up to a given distance
   """
-  def search_users(username: query_string) do
+  def search_users(query) do
     DB.Repo.all(
       from u in User,
       where: fragment(
-        "levenshtein(lower(?), lower(?))", u.username, ^query_string
+        "levenshtein(lower(?), lower(?))", u.username, ^query
       ) < ^levenshtein_distance(),
-      order_by: fragment("levenshtein(lower(?), lower(?))", u.username, ^query_string),
-      limit: 10
-    )
-  end
-
-  @doc """
-  Searches for users by `email`. Uses levenshtein distance
-  to determine matches, up to a distance of 5.
-  """
-  def search_users(email: query_string) do
-    DB.Repo.all(
-      from u in User,
-      where: fragment(
-        "levenshtein(lower(?), lower(?))", u.email, ^query_string
+      or_where: fragment(
+        "levenshtein(lower(?), lower(?))", u.email, ^query
       ) < ^levenshtein_distance(),
-      order_by: fragment("levenshtein(lower(?), lower(?))", u.email, ^query_string),
+      order_by: fragment("levenshtein(lower(?), lower(?))", u.username, ^query),
       limit: 10
     )
   end

--- a/apps/db/test/user_test.exs
+++ b/apps/db/test/user_test.exs
@@ -57,42 +57,42 @@ defmodule DB.UserTest do
     end
 
     test "by exact username returns a user", %{user: user} do
-      [searched_user] = DB.User.search_users(username: @params.username)
+      [searched_user] = DB.User.search_users(@params.username)
       assert searched_user.username == user.username
     end
 
     test "by exact username, case insensitive, returns a user", %{user: user} do
       [searched_user] =
-        DB.User.search_users(username: String.upcase(@params.username))
+        DB.User.search_users(String.upcase(@params.username))
       assert searched_user.username == user.username
     end
 
     test "by fuzzy username, distance 4 returns a user", %{user: user} do
-      [searched_user] = DB.User.search_users(username: "obi")
+      [searched_user] = DB.User.search_users("obi")
       assert searched_user.username == user.username
     end
 
     test "by fuzzy username, distance 5 or greater returns nothing" do
-      assert [] = DB.User.search_users(username: "ob")
+      assert [] = DB.User.search_users("ob")
     end
 
     test "by exact email returns a user", %{user: user} do
-      [searched_user] = DB.User.search_users(email: @params.email)
+      [searched_user] = DB.User.search_users(@params.email)
       assert searched_user.username == user.username
     end
 
     test "by exact email, case insensitive returns a user", %{user: user} do
-      [searched_user] = DB.User.search_users(email: String.upcase(@params.email))
+      [searched_user] = DB.User.search_users(String.upcase(@params.email))
       assert searched_user.username == user.username
     end
 
     test "by fuzzy email, distance 4 returns a user", %{user: user} do
-      [searched_user] = DB.User.search_users(email: "obiwan@jedicouncil.net")
+      [searched_user] = DB.User.search_users("obiwan@jedicouncil.net")
       assert searched_user.username == user.username
     end
 
     test "by fuzzy email, distance 5 or greater returns nothing" do
-      assert [] = DB.User.search_users(email: "obi-wan")
+      assert [] = DB.User.search_users("@jedicouncil")
     end
   end
 end


### PR DESCRIPTION
We'll now have clients search with a general `q` parameter
that will in turn search for `User`s by `email` or `username`.
The major change involves a combination of what was previously
two different queries.