### PR TITLE
Don't let users request themselves as friends

### DIFF
--- a/apps/api/lib/api/user/user.ex
+++ b/apps/api/lib/api/user/user.ex
@@ -10,5 +10,5 @@ defmodule API.User do
   def login(attrs), do: Authorization.authorize(attrs)
 
   def get_by_username(username), do: DB.User.get_by_username(username)
-  def search_users(query, options), do: DB.User.search_users(query, options)
+  def search_users(query, options \\ []), do: DB.User.search_users(query, options)
 end

--- a/apps/api/lib/api/user/user.ex
+++ b/apps/api/lib/api/user/user.ex
@@ -10,5 +10,5 @@ defmodule API.User do
   def login(attrs), do: Authorization.authorize(attrs)
 
   def get_by_username(username), do: DB.User.get_by_username(username)
-  def search_users(params), do: DB.User.search_users(params)
+  def search_users(query, options), do: DB.User.search_users(query, options)
 end

--- a/apps/api/lib/api/web/controllers/user_controller.ex
+++ b/apps/api/lib/api/web/controllers/user_controller.ex
@@ -4,7 +4,8 @@ defmodule API.Web.UserController do
   action_fallback API.Web.FallbackController
 
   def search(conn, %{"q" => query}) do
-    users = API.User.search_users(query)
+    current_user = Guardian.Plug.current_resource(conn)
+    users = API.User.search_users(query, except: current_user)
 
     conn
     |> put_status(:ok)

--- a/apps/db/lib/friend_request/friend_request.ex
+++ b/apps/db/lib/friend_request/friend_request.ex
@@ -29,6 +29,11 @@ defmodule DB.FriendRequest do
     |> Repo.insert
   end
 
+  def create(requesting_user_id, requested_user_id)
+    when requesting_user_id == requested_user_id do
+      {:error, ["Users cannot request themselves"]}
+  end
+
   def delete(id) do
     case Repo.get(FriendRequest, id) do
       nil -> {:error, ["friend request does not exist"]}

--- a/apps/db/lib/user/user.ex
+++ b/apps/db/lib/user/user.ex
@@ -39,23 +39,7 @@ defmodule DB.User do
     ))
   end
 
-  @doc """
-  Searches for users by `email` or `username`. Uses levenshtein distance
-  to determine matches, up to a given distance
-  """
-  def search_users(query) do
-    DB.Repo.all(
-      from u in User,
-      where: fragment(
-        "levenshtein(lower(?), lower(?))", u.username, ^query
-      ) < ^levenshtein_distance(),
-      or_where: fragment(
-        "levenshtein(lower(?), lower(?))", u.email, ^query
-      ) < ^levenshtein_distance(),
-      order_by: fragment("levenshtein(lower(?), lower(?))", u.username, ^query),
-      limit: 10
-    )
-  end
+  def search_users(query, options \\ [])
 
   @doc """
   Searches for users by `email` or `username`. Uses levenshtein distance
@@ -75,6 +59,24 @@ defmodule DB.User do
         u.email,
         ^query
       ) < ^levenshtein_distance() and u.id != ^user.id,
+      order_by: fragment("levenshtein(lower(?), lower(?))", u.username, ^query),
+      limit: 10
+    )
+  end
+
+  @doc """
+  Searches for users by `email` or `username`. Uses levenshtein distance
+  to determine matches, up to a given distance
+  """
+  def search_users(query, _options) do
+    DB.Repo.all(
+      from u in User,
+      where: fragment(
+        "levenshtein(lower(?), lower(?))", u.username, ^query
+      ) < ^levenshtein_distance(),
+      or_where: fragment(
+        "levenshtein(lower(?), lower(?))", u.email, ^query
+      ) < ^levenshtein_distance(),
       order_by: fragment("levenshtein(lower(?), lower(?))", u.username, ^query),
       limit: 10
     )

--- a/apps/db/test/friend_request_test.exs
+++ b/apps/db/test/friend_request_test.exs
@@ -47,6 +47,12 @@ defmodule DB.FriendRequestTest do
 
       refute changeset.valid?
     end
+
+    test "with the same id for requesting and requested returns and error",
+      %{user_one: user} do
+        msg = ["Users cannot request themselves"]
+        {:error, ^msg} = FriendRequest.create(user.id, user.id)
+    end
   end
 
   describe "#list_by_user" do

--- a/apps/db/test/user_test.exs
+++ b/apps/db/test/user_test.exs
@@ -94,5 +94,19 @@ defmodule DB.UserTest do
     test "by fuzzy email, distance 5 or greater returns nothing" do
       assert [] = DB.User.search_users("@jedicouncil")
     end
+
+    test "with an `except` option excludes a user by username", %{user: user} do
+      params = %{@params | username: "Obi Wan", email: "obiwan@jedicouncil"}
+      {:ok, other_user} = DB.User.create(params)
+      [result] = DB.User.search_users(@params.username, except: user)
+      assert result.username == other_user.username
+    end
+
+    test "with an `except` option excludes a user by email", %{user: user} do
+      params = %{@params | username: "Old Ben Kenobi", email: "obi-wan@jedicouncil"}
+      {:ok, other_user} = DB.User.create(params)
+      [result] = DB.User.search_users(@params.email, except: user)
+      assert result.email == other_user.email
+    end
   end
 end


### PR DESCRIPTION
This PR does the following:
- Excludes the requesting User from a search
  - Updates `DB.User.search_users` to take options. Introduces `except` option, which takes a `DB.User` and excludes it from the search, but can be extended to other options (i.e. `limit`)
  - Applies options to the User search endpoint
- Prevents users from requesting themselves (defensive, but avoids a very dangerous situation). Checks if `FriendRequest.create` is receiving the same argument twice for requesting and requested

![](https://media.giphy.com/media/WynKmCK0LwykM/giphy.gif)