### PR TITLE
Add start time to Game

### DIFF
--- a/api_docs/game.md
+++ b/api_docs/game.md
@@ -36,17 +36,18 @@
 **Parameters:**
 
 |**Name**|**Type**|**Required**|**Description**|
-| ------------ |-------- | ---------- | ------------- |
-| status       | string  | Yes        | Must be one of `pending`, `active`, `complete` |
-| round_length | integer | Yes        | Length of the round in days |
-| title        | string  | No         | Optional name for the game |
+| ------------ |--------- | ---------- | ------------- |
+| round_length | integer  | Yes        | Length of the round in days |
+| start_time   | datetime | Yes        | The start time of the game |
+| title        | string   | No         | Optional name for the game |
 
 **Example Request:**
 
 ```json
 {
   "title": "zombieland",
-  "round_length": 5
+  "round_length": 5,
+  "start_time": "2017-09-28 06:05:00.926573Z"
 }
 ```
 

--- a/apps/api/lib/api/web/views/game_view.ex
+++ b/apps/api/lib/api/web/views/game_view.ex
@@ -16,6 +16,7 @@ defmodule API.Web.GameView do
       title: game.title,
       status: game.status,
       round_length: game.round_length,
+      start_time: game.start_time,
       player: get_player_info(user, game)
     }
   end

--- a/apps/api/test/api/web/controllers/game_controller_test.exs
+++ b/apps/api/test/api/web/controllers/game_controller_test.exs
@@ -7,7 +7,8 @@ defmodule API.Web.GameControllerTest do
 
   @game_params %{
     "title" => @title,
-    "round_length" => @round_length
+    "round_length" => @round_length,
+    "start_time" => DateTime.utc_now()
   }
 
   setup do

--- a/apps/api/test/support/factories/game_factory.ex
+++ b/apps/api/test/support/factories/game_factory.ex
@@ -12,7 +12,8 @@ defmodule API.Game.Factory do
       title: "Obi-Wan's Game",
       status: "qualifying",
       round_length: 100,
-      owner_id: API.User.Factory.create_user().id
+      owner_id: API.User.Factory.create_user().id,
+      start_time: DateTime.utc_now()
     }
   end
 end

--- a/apps/db/lib/game/game.ex
+++ b/apps/db/lib/game/game.ex
@@ -14,6 +14,7 @@ defmodule DB.Game do
     field :title, :string
     field :owner_id, :integer
     field :round_length, :integer
+    field :start_time, :utc_datetime
 
     many_to_many :users, User, join_through: Player
     has_many :players, Player
@@ -21,8 +22,8 @@ defmodule DB.Game do
     timestamps()
   end
 
-  @fields [:status, :title, :owner_id, :round_length]
-  @required_fields [:status, :round_length, :owner_id]
+  @fields [:status, :title, :owner_id, :round_length, :start_time]
+  @required_fields [:status, :round_length, :owner_id, :start_time]
   @accepted_statuses ~w(qualifying active complete)
 
   def get(game_id), do: Repo.get(Game, game_id)

--- a/apps/db/priv/repo/migrations/20170928042914_add_start_time_to_games.exs
+++ b/apps/db/priv/repo/migrations/20170928042914_add_start_time_to_games.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddStartTimeToGames do
+  use Ecto.Migration
+
+  def change do
+    alter table(:games) do
+      add :start_time, :utc_datetime, null: false
+    end
+  end
+end

--- a/apps/db/test/game_test.exs
+++ b/apps/db/test/game_test.exs
@@ -7,7 +7,8 @@ defmodule DB.GameTest do
     title: "Obi-Wan's Game",
     status: "qualifying",
     round_length: 100,
-    owner_id: 1
+    owner_id: 1,
+    start_time: DateTime.utc_now()
   }
 
   describe "#create" do

--- a/apps/db/test/support/factories/game_factory.ex
+++ b/apps/db/test/support/factories/game_factory.ex
@@ -12,7 +12,8 @@ defmodule DB.Game.Factory do
       title: "Obi-Wan's Game",
       status: "qualifying",
       round_length: 100,
-      owner_id: DB.User.Factory.create_user().id
+      owner_id: DB.User.Factory.create_user().id,
+      start_time: DateTime.utc_now()
     }
   end
 end


### PR DESCRIPTION
Allows the Games API to accept a `start_time`, which in our flow represents the time at midnight for the requesting user, converted to UTC. Conversion to and from local timezones will occur on the client, and the server will only deal in UTC. We mentioned GMT earlier but in practice they are the same, though technically one is a timezone and the other is a time standard.